### PR TITLE
Fix missing thank you view

### DIFF
--- a/bookings/views.py
+++ b/bookings/views.py
@@ -78,3 +78,8 @@ def public_booking_view(request):
 
     return render(request, 'bookings/public_booking.html', {'form': form})
 
+
+def thank_you_view(request):
+    """Render a simple confirmation page after a booking is submitted."""
+    return render(request, 'bookings/thank_you.html')
+


### PR DESCRIPTION
## Summary
- add missing `thank_you_view` to ensure `thank-you/` URL works

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e57b8b9388324b7af9827bd0133ef