### PR TITLE
Fix missing view for thank-you page

### DIFF
--- a/bookings/views.py
+++ b/bookings/views.py
@@ -78,3 +78,8 @@ def public_booking_view(request):
 
     return render(request, 'bookings/public_booking.html', {'form': form})
 
+
+def thank_you_view(request):
+    """Display a simple confirmation page after a booking."""
+    return render(request, 'bookings/thank_you.html')
+


### PR DESCRIPTION
## Summary
- add `thank_you_view` view rendering the template

## Testing
- `python -m py_compile bookings/views.py`


------
https://chatgpt.com/codex/tasks/task_e_684e57975cfc8324af2fe8d5aa1b7b3a