### PR TITLE
Fix missing thank-you view and calendar import error

### DIFF
--- a/bookings/google_calendar.py
+++ b/bookings/google_calendar.py
@@ -10,19 +10,19 @@ SCOPES = ['https://www.googleapis.com/auth/calendar']
 
 # Load the raw JSON string from the env var
 raw_creds = os.getenv('GOOGLE_CREDS')
-if not raw_creds:
-    raise ValueError("GOOGLE_CREDS env variable not set. Paste your service account JSON here.")
 
-# Parse it
-service_account_info = json.loads(raw_creds)
+service = None
+if raw_creds:
+    # Parse it
+    service_account_info = json.loads(raw_creds)
 
-# Build credentials object
-credentials = service_account.Credentials.from_service_account_info(
-    service_account_info, scopes=SCOPES
-)
+    # Build credentials object
+    credentials = service_account.Credentials.from_service_account_info(
+        service_account_info, scopes=SCOPES
+    )
 
-# Construct the Calendar API client
-service = build('calendar', 'v3', credentials=credentials)
+    # Construct the Calendar API client
+    service = build('calendar', 'v3', credentials=credentials)
 
 # Which calendar to write to? You can also set this in ENV: CALENDAR_ID
 CALENDAR_ID = os.getenv('CALENDAR_ID', 'your-account@gmail.com')
@@ -32,10 +32,14 @@ def create_event(summary: str, start_datetime: datetime, end_datetime: datetime)
     """
     Creates an event on your Google Calendar.
     summary: text title
-    start_datetime, end_datetime: timezone-naive datetimes in local tz
+    start_datetime, end_datetime: timezone-aware datetimes
     """
     # pick your timezone
     tz = os.getenv('CALENDAR_TZ', 'America/New_York')
+
+    if service is None:
+        print("\u274c Google Calendar service not configured. Skipping event creation.")
+        return None
 
     event = {
         'summary': summary,

--- a/bookings/tests/test_views.py
+++ b/bookings/tests/test_views.py
@@ -1,0 +1,9 @@
+from django.urls import reverse
+from django.test import TestCase
+
+
+class ThankYouViewTests(TestCase):
+    def test_thank_you_page(self):
+        response = self.client.get(reverse('thank_you'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Thank You")

--- a/bookings/views.py
+++ b/bookings/views.py
@@ -78,3 +78,8 @@ def public_booking_view(request):
 
     return render(request, 'bookings/public_booking.html', {'form': form})
 
+
+def thank_you_view(request):
+    """Simple page shown after a successful booking."""
+    return render(request, 'bookings/thank_you.html')
+


### PR DESCRIPTION
## Summary
- add a simple `thank_you_view`
- don't require Google credentials during import and handle missing service
- add basic test for thank-you view

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e56ce09308324bf52da4785bcc2c5