### PR TITLE
Fix calendar integration crash when creds missing

### DIFF
--- a/bookings/google_calendar.py
+++ b/bookings/google_calendar.py
@@ -8,21 +8,29 @@ from googleapiclient.discovery import build
 # Scopes your service account needs
 SCOPES = ['https://www.googleapis.com/auth/calendar']
 
-# Load the raw JSON string from the env var
-raw_creds = os.getenv('GOOGLE_CREDS')
-if not raw_creds:
-    raise ValueError("GOOGLE_CREDS env variable not set. Paste your service account JSON here.")
 
-# Parse it
-service_account_info = json.loads(raw_creds)
+# Load the raw JSON string from the env var. When running locally the
+# ``GOOGLE_CREDS`` variable may not be provided. Instead of raising an error
+# and crashing the app, gracefully disable the calendar integration so the rest
+# of the site can still function.
+raw_creds = os.getenv("GOOGLE_CREDS")
+service = None
 
-# Build credentials object
-credentials = service_account.Credentials.from_service_account_info(
-    service_account_info, scopes=SCOPES
-)
-
-# Construct the Calendar API client
-service = build('calendar', 'v3', credentials=credentials)
+if raw_creds:
+    try:
+        # Parse the JSON credentials and construct the Calendar API client
+        service_account_info = json.loads(raw_creds)
+        credentials = service_account.Credentials.from_service_account_info(
+            service_account_info, scopes=SCOPES
+        )
+        service = build("calendar", "v3", credentials=credentials)
+    except Exception as e:
+        # If anything goes wrong (malformed JSON, etc.), log the issue and
+        # continue without Google Calendar enabled.
+        print(f"Failed to configure Google Calendar service: {e}")
+else:
+    # Environment variable missing
+    print("GOOGLE_CREDS not set. Google Calendar integration disabled.")
 
 # Which calendar to write to? You can also set this in ENV: CALENDAR_ID
 CALENDAR_ID = os.getenv('CALENDAR_ID', 'your-account@gmail.com')
@@ -37,15 +45,21 @@ def create_event(summary: str, start_datetime: datetime, end_datetime: datetime)
     # pick your timezone
     tz = os.getenv('CALENDAR_TZ', 'America/New_York')
 
+    if service is None:
+        # No Google Calendar credentials configured, so simply skip creating the
+        # event. Returning None keeps the calling code simple.
+        print("Google Calendar service not configured; skipping event creation.")
+        return None
+
     event = {
-        'summary': summary,
-        'start': {
-            'dateTime': start_datetime.astimezone(pytz.timezone(tz)).isoformat(),
-            'timeZone': tz,
+        "summary": summary,
+        "start": {
+            "dateTime": start_datetime.astimezone(pytz.timezone(tz)).isoformat(),
+            "timeZone": tz,
         },
-        'end': {
-            'dateTime': end_datetime.astimezone(pytz.timezone(tz)).isoformat(),
-            'timeZone': tz,
+        "end": {
+            "dateTime": end_datetime.astimezone(pytz.timezone(tz)).isoformat(),
+            "timeZone": tz,
         },
     }
 


### PR DESCRIPTION
## Summary
- gracefully handle missing `GOOGLE_CREDS`
- skip event creation when the calendar service is not configured

## Testing
- `python3 manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e5a9ba968832487203bdc217b43bf