### PR TITLE
Fix thank you view crash

### DIFF
--- a/bookings/views.py
+++ b/bookings/views.py
@@ -78,3 +78,8 @@ def public_booking_view(request):
 
     return render(request, 'bookings/public_booking.html', {'form': form})
 
+
+def thank_you_view(request):
+    """Simple page displayed after a successful booking."""
+    return render(request, 'bookings/thank_you.html')
+


### PR DESCRIPTION
## Summary
- add a missing `thank_you_view` to render the thank you page after booking

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684e6177cf94832489dac732c9acc0a2