### PR TITLE
Add admin notification email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-"# smart-scheduler" 
-"# smart-scheduler" 
+# Smart Scheduler
+
+Set the `ADMIN_EMAIL` environment variable if you want booking confirmations
+sent to an additional address. If unset, notifications are sent to
+`corvette052@gmail.com` by default.

--- a/bookings/views.py
+++ b/bookings/views.py
@@ -16,6 +16,9 @@ import pytz
 tz_name = os.getenv("CALENDAR_TZ", "America/New_York")
 local_tz = pytz.timezone(tz_name)
 
+# Additional email address to receive booking notifications
+ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "corvette052@gmail.com")
+
 def public_booking_view(request):
     if request.method == 'POST':
         form = PublicBookingForm(request.POST)
@@ -73,7 +76,12 @@ def public_booking_view(request):
                 f"📍 {booking.address}, {booking.zip_code}\n\n"
                 "See you soon!\n— Your Company"
             )
-            send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [booking.email])
+            send_mail(
+                subject,
+                message,
+                settings.DEFAULT_FROM_EMAIL,
+                [booking.email, ADMIN_EMAIL]
+            )
 
             return redirect('thank_you')
     else:


### PR DESCRIPTION
## Summary
- add optional `ADMIN_EMAIL` env var for an extra notification
- document the variable in README

## Testing
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e6bc1ffa083248212d2071d2a7550