### PR TITLE
Implement 2.5 hour booking blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Set the `ADMIN_EMAIL` environment variable if you want booking confirmations
 sent to an additional address. If unset, notifications are sent to
 `corvette052@gmail.com` by default.
+
+Each appointment blocks out two and a half hours which accounts for both the
+1.5‑hour tinting job and an additional hour of travel time. For example, a
+booking at **10:00 AM** will make **12:30 PM** the next available slot.

--- a/bookings/utils.py
+++ b/bookings/utils.py
@@ -16,12 +16,18 @@ def get_available_slots():
         current = datetime.combine(date, WORK_START)
         end = datetime.combine(date, WORK_END)
 
+        bookings = list(Booking.objects.filter(date=date))
+
         while current + JOB_DURATION <= end:
-            overlap = Booking.objects.filter(
-                date=date,
-                start_time__lt=(current + BLOCK_TIME).time(),
-                end_time__gt=current.time()
-            ).exists()
+            overlap = False
+
+            for booking in bookings:
+                booking_start = datetime.combine(date, booking.start_time)
+                block_end = booking_start + BLOCK_TIME
+
+                if booking_start <= current < block_end:
+                    overlap = True
+                    break
 
             if not overlap and current > now:
                 slots.append({


### PR DESCRIPTION
## Summary
- enforce 2.5‑hour block after each booking when generating available slots
- document the 2.5‑hour block in the README

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails due to network restrictions)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e6d2c457883248cf9b0148371f04d