### PR TITLE
Resolve README merge conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Smart Scheduler
 
-Set the `ADMIN_EMAIL` environment variable if you want booking confirmations
-sent to an additional address. If unset, notifications are sent to
-`corvette052@gmail.com` by default.
+Set the `ADMIN_EMAILS` environment variable to a comma-separated list if you want booking confirmations sent to multiple addresses. If unset, notifications are sent to `corvette052@gmail.com` by default.
 
-Each appointment blocks out two and a half hours which accounts for both the
-1.5‑hour tinting job and an additional hour of travel time. For example, a
-booking at **10:00 AM** will make **12:30 PM** the next available slot.
+Use `CALENDAR_IDS` to specify one or more Google Calendar IDs (comma-separated) that should receive each booking. If not provided, the single `CALENDAR_ID` variable or a default calendar of `your-account@gmail.com` is used.
+
+Each appointment blocks out two and a half hours which accounts for both the 1.5‑hour tinting job and an additional hour of travel time. For example, a booking at **10:00 AM** will make **12:30 PM** the next available slot.


### PR DESCRIPTION
## Summary
- clarify `ADMIN_EMAILS` and `CALENDAR_IDS` usage
- note default fallback email and calendar IDs
- mention 2.5‑hour booking window

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e715061c883248e0e883a7a0053ea