### PR TITLE
Remove duplicate host setting

### DIFF
--- a/scheduler/settings.py
+++ b/scheduler/settings.py
@@ -137,5 +137,4 @@ DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 CSRF_TRUSTED_ORIGINS = [
     'https://smart-scheduler-production.up.railway.app'
 ]
-ALLOWED_HOSTS = ['smart-scheduler-production.up.railway.app', 'localhost', '127.0.0.1']
 


### PR DESCRIPTION
## Summary
- remove duplicate `ALLOWED_HOSTS` entry in `settings.py`
- delete placeholder `Nuevo Text Document.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e739fb8b88324a8c64c2f69a3f577