### PR TITLE
Handle missing email credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ manager:
 - `EMAIL_HOST_USER` – email account used to send booking confirmations.
 - `EMAIL_HOST_PASSWORD` – app password for the above account.
 - `GOOGLE_CREDS` – JSON credentials for the Google Calendar service account.
+
+If `EMAIL_HOST_USER` and `EMAIL_HOST_PASSWORD` are omitted, the application now
+logs a warning and continues without sending emails. Bookings are still saved
+and added to Google Calendar.

--- a/bookings/views.py
+++ b/bookings/views.py
@@ -79,12 +79,15 @@ def public_booking_view(request):
                 f"📍 {booking.address}, {booking.zip_code}\n\n"
                 "See you soon!\n— Your Company"
             )
-            send_mail(
-                subject,
-                message,
-                settings.DEFAULT_FROM_EMAIL,
-                [booking.email] + ADMIN_EMAILS
-            )
+            try:
+                send_mail(
+                    subject,
+                    message,
+                    settings.DEFAULT_FROM_EMAIL,
+                    [booking.email] + ADMIN_EMAILS
+                )
+            except Exception as e:
+                print(f"\u26a0\ufe0f Failed to send confirmation email: {e}")
 
             return redirect('thank_you')
     else:


### PR DESCRIPTION
## Summary
- catch errors when sending confirmation emails
- mention that emails are optional in README

## Testing
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684eac42ab2083249d50f6e306d8cd0c