### PR TITLE
Fix Procfile syntax for Nixpacks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web gunicorn scheduler.wsgi
+web: gunicorn scheduler.wsgi


### PR DESCRIPTION
## Summary
- fix process entry in `Procfile`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_684ebbc3d2b083248ce35ce856ea9830