### PR TITLE
Update README with migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ manager:
 If `EMAIL_HOST_USER` and `EMAIL_HOST_PASSWORD` are omitted, the application now
 logs a warning and continues without sending emails. Bookings are still saved
 and added to Google Calendar.
+
+## Initial setup
+
+After deploying to a new environment, run migrations to create the SQLite database:
+
+```bash
+python manage.py migrate
+```
+
+This step is required the first time the app runs on Railway since the container starts with an empty filesystem.


### PR DESCRIPTION
## Summary
- document running `python manage.py migrate` after deploying

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eeac25d7883248a9c0bd9d65d073f