### PR TITLE
Add Google Calendar link to public booking form

### DIFF
--- a/bookings/templates/public_booking_form.html
+++ b/bookings/templates/public_booking_form.html
@@ -1,4 +1,8 @@
 <h2>Book an Appointment</h2>
+<p>
+  You can also schedule directly through
+  <a href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ3U8dldiPMQGV6xaD6FzB8sJTjVqZ2Ar9iDwJNe0z3PIAftp-LmLIB1DT3UXS6iwhBHShoQESwc" target="_blank" rel="noopener">Google Calendar</a>.
+</p>
 <form method="post">
   {% csrf_token %}
   {{ form.as_p }}


### PR DESCRIPTION
## Summary
- provide an alternate way to schedule by linking to Google Calendar

## Testing
- `venv/Scripts/python.exe manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_684f396cdedc8324916fa3e5de3c6145