### PR TITLE
Add marketing form page

### DIFF
--- a/bookings/templates/bookings/marketing_form.html
+++ b/bookings/templates/bookings/marketing_form.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Claim Offer</title>
+    <style>
+        html, body {
+            margin: 0;
+            height: 100%;
+        }
+        .iframe-container {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+<body>
+    <div class="iframe-container">
+        <iframe
+            src="https://link.derosales.com/widget/form/WHAfCqGoljYX0wn8c5jF"
+            style="width:100%;height:100%;border:none;border-radius:4px"
+            id="inline-WHAfCqGoljYX0wn8c5jF"
+            data-layout="{'id':'INLINE'}"
+            data-trigger-type="alwaysShow"
+            data-trigger-value=""
+            data-activation-type="alwaysActivated"
+            data-activation-value=""
+            data-deactivation-type="neverDeactivate"
+            data-deactivation-value=""
+            data-form-name="Marketing Form - Claim Offer"
+            data-height="779"
+            data-layout-iframe-id="inline-WHAfCqGoljYX0wn8c5jF"
+            data-form-id="WHAfCqGoljYX0wn8c5jF"
+            title="Marketing Form - Claim Offer">
+        </iframe>
+    </div>
+    <script src="https://link.derosales.com/js/form_embed.js"></script>
+</body>
+</html>

--- a/bookings/views.py
+++ b/bookings/views.py
@@ -109,3 +109,7 @@ def thank_you_view(request):
     """Simple page displayed after a successful booking."""
     return render(request, 'bookings/thank_you.html')
 
+
+def marketing_form_view(request):
+    """Display an embedded marketing form served from link.derosales.com."""
+    return render(request, 'bookings/marketing_form.html')

--- a/scheduler/urls.py
+++ b/scheduler/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path('', lambda request: redirect('booking', permanent=False)),  # Redirect /
     path('admin/', admin.site.urls),
     path('book/', views.public_booking_view, name='booking'),
+    path('claim-offer/', views.marketing_form_view, name='claim_offer'),
     path('thank-you/', views.thank_you_view, name='thank_you'),
 ]


### PR DESCRIPTION
## Summary
- embed a marketing form from link.derosales.com
- expose new `claim-offer/` route for the form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3e5ed818832499f278ee9ac98ad2